### PR TITLE
#102 sample names with spaces

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -234,7 +234,7 @@ namespace torali
     bool rgPresent = false;
     for(;itH!=itHEnd; ++itH) {
       if (itH->find("@RG")==0) {
-	std::string delim("\t ");
+	std::string delim("\t");
 	TStrParts keyval;
 	boost::split(keyval, *itH, boost::is_any_of(delim));
 	TStrParts::const_iterator itKV = keyval.begin();

--- a/src/util.h
+++ b/src/util.h
@@ -394,7 +394,7 @@ namespace torali
       bool rgPresent = false;
       for(;itH!=itHEnd; ++itH) {
 	if (itH->find("@RG")==0) {
-	  std::string delim("\t ");
+	  std::string delim("\t");
 	  TStrParts keyval;
 	  boost::split(keyval, *itH, boost::is_any_of(delim));
 	  TStrParts::const_iterator itKV = keyval.begin();


### PR DESCRIPTION
I think this should fix the issue I reported here: https://github.com/dellytools/delly/issues/102 where delly doesn't read sample names with spaces correctly. I confirmed that compiling the changed `util.h` make sample names with spaces work, but don't know the code anywhere _near_ enough to know whether it would affect anything else. 

If this works, great. If I can help by further testing, please let me know, I'd be happy to. 

Thanks for a great tool! 