### PR TITLE
documented INS and DEL support for lr mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Delly needs a sorted, indexed and duplicate marked bam file for every input samp
 Delly for long reads from PacBio or ONT (experimental)
 ------------------------------------------------------
 
-Delly also has a long-read SV discovery mode.
+Delly also has a long-read SV discovery mode (currently, only INS and DEL are supported).
 
 `delly lr -y ont -g hg19.fa -x hg19.excl input.bam`
 

--- a/src/delly.cpp
+++ b/src/delly.cpp
@@ -33,7 +33,7 @@ displayUsage() {
   std::cout << "    filter       filter somatic or germline structural variants" << std::endl;
   std::cout << std::endl;
   std::cout << "Long-read commands:" << std::endl;
-  std::cout << "    lr           long-read SV discovery" << std::endl;
+  std::cout << "    lr           long-read SV discovery (currently, only INS and DEL are supported)" << std::endl;
   std::cout << std::endl;
   std::cout << "Read-depth commands:" << std::endl;
   std::cout << "    rd           read-depth normalization" << std::endl;


### PR DESCRIPTION
Added a short note about SVTYPE support in lr mode.
delly in lr mode with -t [DUP|INV|BND] takes ~3 hours with GIAB H002 ONT Ultralong reads (for each SVTYPE). The output is predictably empty.
Documenting the supported SVTYPEs will reduce confusion and rsources.