### PR TITLE
chore: package python script `delly2bnd` for bioconda recipe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "delly-scripts"
+dynamic = ["version"]
+description = 'Python scripts to do with delly.'
+readme = "scripts/README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+keywords = []
+authors = [
+  { name = "Tobias Rausch", email = "rauschtobi@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+
+dependencies = [
+  "cyvcf2>=0.31.1, <0.32"
+]
+
+[project.urls]
+Documentation = "https://github.com/dellytools/delly/tree/main/scripts#readme"
+Issues = "https://github.com/dellytools/delly/issues"
+Source = "https://github.com/dellytools/delly"
+
+[project.scripts]
+delly2bnd = "scripts.delly2bnd:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scripts"]
+
+[tool.hatch.version]
+path = "src/version.h"
+pattern = "std::string dellyVersionNumber = \"(?P<version>[^\"]+)\";"

--- a/scripts/delly2bnd.py
+++ b/scripts/delly2bnd.py
@@ -1,29 +1,72 @@
 #! /usr/bin/env python
 
 from __future__ import print_function
-from readfq import readfq
+from .readfq import readfq
 import argparse
 import sys
 import cyvcf2
 import collections
 
-# Parse command line
-parser = argparse.ArgumentParser(description='Split BND calls')
-parser.add_argument('-v', '--vcf', metavar='input.vcf.gz', required=True, dest='vcf', help='input VCF/BCF file (required)')
-parser.add_argument('-r', '--ref', metavar='ref.fa', required=True, dest='ref', help='input reference (required)')
-parser.add_argument('-o', '--out', metavar='out.vcf', required=True, dest='out', help='output VCF file (required)')
-args = parser.parse_args()
+def argument_parsing():
+    """
+    Parse command-line options.
+    """
+    parser = argparse.ArgumentParser(description='Split BND calls')
+    parser.add_argument('-v', '--vcf', metavar='input.vcf.gz', required=True, dest='vcf', help='input VCF/BCF file (required)')
+    parser.add_argument('-r', '--ref', metavar='ref.fa', required=True, dest='ref', help='input reference (required)')
+    parser.add_argument('-o', '--out', metavar='out.vcf', required=True, dest='out', help='output VCF file (required)')
+    return parser.parse_args()
 
-# Fetch breakpoint positions
-bndPos = collections.defaultdict(dict)
-oldChr = None
-if not len(bndPos):
+def delly2bnd(args):
+    # Fetch breakpoint positions
+    bndPos = collections.defaultdict(dict)
+    oldChr = None
+    if not len(bndPos):
+        vcf = cyvcf2.VCF(args.vcf)
+        for record in vcf:
+            if record.CHROM != oldChr:
+                oldChr = record.CHROM
+                print("Fetching BND calls...", oldChr, file=sys.stderr)
+
+            # Ignore multi-allelics
+            if len(record.ALT) > 1:
+                continue
+
+            # Only delly BND and TRA calls
+            if record.INFO.get("SVTYPE") == "BND":
+                ct = record.INFO.get("CT")
+                chrom2 = record.INFO.get("CHR2")
+                pos2 = record.INFO.get("POS2")
+            elif record.INFO.get("SVTYPE") == "TRA":
+                ct = record.INFO.get("CT")
+                chrom2 = record.INFO.get("CHR2")
+                pos2 = record.INFO.get("END")
+            else:
+                continue
+            chrom = record.CHROM
+            pos = record.POS
+            bndPos[chrom][pos] = 'N'
+            bndPos[chrom2][pos2] = 'N'
+
+        # Fetch nucleotides
+        if True:
+            f_in = gzip.open(args.ref) if args.ref.endswith('.gz') else open(args.ref)
+            for seqName, seqNuc, seqQuals in readfq(f_in):
+                if seqName in bndPos.keys():
+                    print("Fetching breakpoint nucleotides...", seqName, file=sys.stderr)
+                    for pos in bndPos[seqName].keys():
+                        bndPos[seqName][pos] = seqNuc[(pos-1):pos]
+
+    # Parse VCF/BCF
     vcf = cyvcf2.VCF(args.vcf)
+    vcf.add_info_to_header({'ID': 'MATEID', 'Description': 'ID of mate breakends', 'Type':'String', 'Number': '.'})
+    w = cyvcf2.Writer(args.out, vcf)
+    oldChr = None
     for record in vcf:
         if record.CHROM != oldChr:
             oldChr = record.CHROM
-            print("Fetching BND calls...", oldChr, file=sys.stderr)
-            
+            print("Processing...", oldChr, file=sys.stderr)
+
         # Ignore multi-allelics
         if len(record.ALT) > 1:
             continue
@@ -41,80 +84,50 @@ if not len(bndPos):
             continue
         chrom = record.CHROM
         pos = record.POS
-        bndPos[chrom][pos] = 'N'
-        bndPos[chrom2][pos2] = 'N'
+        id1 = record.ID + "_2nd"
+        id2 = record.ID + "_1st"
+        if ct == '3to5':
+            template = bndPos[chrom][pos] + "[" + chrom2 + ":" + str(pos2) + "["
+            template2 = "]" + chrom + ":" + str(pos) + "]" + bndPos[chrom2][pos2]
+        elif ct == '5to3':
+            template = "]" + chrom2 + ":" + str(pos2) + "]" + bndPos[chrom][pos]
+            template2 = bndPos[chrom2][pos2] + "[" + chrom + ":" + str(pos) + "["
+        elif ct == '3to3':
+            template = bndPos[chrom][pos] + "]" + chrom2 + ":" + str(pos2) + "]"
+            template2 = bndPos[chrom2][pos2] + "]" + chrom + ":" + str(pos) + "]"
+        else:
+            template = "[" + chrom2 + ":" + str(pos2) + "[" + bndPos[chrom][pos]
+            template2 = "[" + chrom + ":" + str(pos) + "[" + bndPos[chrom2][pos2]
 
-    # Fetch nucleotides
-    if True:
-        f_in = gzip.open(args.ref) if args.ref.endswith('.gz') else open(args.ref)
-        for seqName, seqNuc, seqQuals in readfq(f_in):
-            if seqName in bndPos.keys():
-                print("Fetching breakpoint nucleotides...", seqName, file=sys.stderr)
-                for pos in bndPos[seqName].keys():
-                    bndPos[seqName][pos] = seqNuc[(pos-1):pos]
+        # 2nd breakend
+        record.ID = id1
+        record.INFO['MATEID'] = id2
+        record.ALT = [template]
+        w.write_record(record)
 
-# Parse VCF/BCF
-vcf = cyvcf2.VCF(args.vcf)
-vcf.add_info_to_header({'ID': 'MATEID', 'Description': 'ID of mate breakends', 'Type':'String', 'Number': '.'})
-w = cyvcf2.Writer(args.out, vcf)
-oldChr = None
-for record in vcf:
-    if record.CHROM != oldChr:
-        oldChr = record.CHROM
-        print("Processing...", oldChr, file=sys.stderr)
-        
-    # Ignore multi-allelics
-    if len(record.ALT) > 1:
-        continue
+        # 1st breakend
+        record.CHROM = chrom2
+        record.set_pos(pos2 - 1)
+        record.ID = id2    
+        record.INFO['MATEID'] = id1
+        record.REF = bndPos[chrom2][pos2]
+        record.ALT = [template2]
+        record.INFO['CHR2'] = chrom
+        record.INFO['POS2'] = pos
+        record.INFO['END'] = pos2 + 1
+        if ct == '5to3':
+            record.INFO['CT'] = '3to5'
+        elif ct == '3to5':
+            record.INFO['CT'] = '5to3'
+        w.write_record(record)
+    # Close file
+    w.close()
 
-    # Only delly BND and TRA calls
-    if record.INFO.get("SVTYPE") == "BND":
-        ct = record.INFO.get("CT")
-        chrom2 = record.INFO.get("CHR2")
-        pos2 = record.INFO.get("POS2")
-    elif record.INFO.get("SVTYPE") == "TRA":
-        ct = record.INFO.get("CT")
-        chrom2 = record.INFO.get("CHR2")
-        pos2 = record.INFO.get("END")
-    else:
-        continue
-    chrom = record.CHROM
-    pos = record.POS
-    id1 = record.ID + "_2nd"
-    id2 = record.ID + "_1st"
-    if ct == '3to5':
-        template = bndPos[chrom][pos] + "[" + chrom2 + ":" + str(pos2) + "["
-        template2 = "]" + chrom + ":" + str(pos) + "]" + bndPos[chrom2][pos2]
-    elif ct == '5to3':
-        template = "]" + chrom2 + ":" + str(pos2) + "]" + bndPos[chrom][pos]
-        template2 = bndPos[chrom2][pos2] + "[" + chrom + ":" + str(pos) + "["
-    elif ct == '3to3':
-        template = bndPos[chrom][pos] + "]" + chrom2 + ":" + str(pos2) + "]"
-        template2 = bndPos[chrom2][pos2] + "]" + chrom + ":" + str(pos) + "]"
-    else:
-        template = "[" + chrom2 + ":" + str(pos2) + "[" + bndPos[chrom][pos]
-        template2 = "[" + chrom + ":" + str(pos) + "[" + bndPos[chrom2][pos2]
 
-    # 2nd breakend
-    record.ID = id1
-    record.INFO['MATEID'] = id2
-    record.ALT = [template]
-    w.write_record(record)
+def main():
+    arguments = argument_parsing()
+    delly2bnd(arguments)
 
-    # 1st breakend
-    record.CHROM = chrom2
-    record.set_pos(pos2 - 1)
-    record.ID = id2    
-    record.INFO['MATEID'] = id1
-    record.REF = bndPos[chrom2][pos2]
-    record.ALT = [template2]
-    record.INFO['CHR2'] = chrom
-    record.INFO['POS2'] = pos
-    record.INFO['END'] = pos2 + 1
-    if ct == '5to3':
-        record.INFO['CT'] = '3to5'
-    elif ct == '3to5':
-        record.INFO['CT'] = '5to3'
-    w.write_record(record)
-# Close file
-w.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
We realized that we would like to programmatically use `delly2bnd.py` to get correct breakend (`BND`) notation for delly results. We would therefore like to be able to also programmatically install this script via `bioconda`.

This pull request is meant to prepare the script for the respective packaging. It follows [the great documentation and tutorials on python packaging provided by pyOpenSci](https://www.pyopensci.org/python-package-guide/package-structure-code/intro.html).

with the resulting package defintion, the idea is to use a [second `outputs:`](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#outputs-section) in the [`meta.yaml` for the `delly` package on `bioconda`](https://github.com/bioconda/bioconda-recipes/blob/ffdea385bba2192459f6d47da3e68eb38fd9838a/recipes/delly/meta.yaml). This would:

1. Make the script installable as a `bioconda` package with the name `delly-scripts`, so `conda install -c conda-forge -c bioconda delly-scripts` would generate an environment in which `delly2bnd` is available as an executable.
2. It would just use the same downloaded tarball that is also used for the main `delly` recipe, and the same version numbers. That way, updating should be automatic and integrated with the packaging of the main `delly` software.

This general setup should also be easy to extend, should you add any further python scripts in the future. I hope you can see our use case and that this is an acceptable setup for you. And please let me know if any of the above needs further explanation.